### PR TITLE
fix(Api): api not working with Stereo 2 because of cookie auth system

### DIFF
--- a/src/client/structures/Api/routes/OauthRoute.ts
+++ b/src/client/structures/Api/routes/OauthRoute.ts
@@ -36,9 +36,11 @@ export class OauthRoute {
 				userId: user.id,
 			});
 
-			res
-				.cookie("STEREO_AUTH", cookie, { maxAge: expires + data.expires_in * 1e3 })
-				.redirect(process.env.DASHBOARD ?? "http://localhost:3000");
+			res.redirect(
+				`${process.env.DASHBOARD ?? "http://localhost:3000"}/callback?cookie=${encodeURIComponent(
+					cookie
+				)}`
+			);
 		} catch (e) {
 			res.status(500).json({ message: "internal server error", error: e.message });
 		}


### PR DESCRIPTION
Stereo 2 doesn't work with the dashboard because of the verification the API uses

- [x] Make callback route on dashboard
- [x] redirect user with cookie to callback

Closes #27 